### PR TITLE
Creating console command for a module throws error

### DIFF
--- a/src/BaseGenerator.php
+++ b/src/BaseGenerator.php
@@ -148,7 +148,7 @@ abstract class BaseGenerator extends BaseObject
 
         if (isset($options['default'])) {
             $options['default'] = Code::normalizeClass($options['default']);
-            if ($options['ensureContained'] && !str_starts_with("{$options['default']}\\", "$this->baseNamespace\\")) {
+            if ($options['ensureContained'] && !str_starts_with("{$options['default']}\\", Code::normalizeClass($this->baseNamespace) . "\\")) {
                 throw new InvalidArgumentException("The default value must begin with the base namespace ($this->baseNamespace).");
             }
         }


### PR DESCRIPTION
On trying to generate a console command for a module, I get the following error after entering the command ID:

`Exception 'yii\base\InvalidArgumentException' with message 'The default value must begin with the base namespace (modules\\site).'`

This is because `$options['default']` is normalized and doesn't contain `\\` anymore, while $this->baseNamespace does. Normalizing the base namespace prevents this from happening.

### Description



### Related issues

