### PR TITLE
Element Types + ECS Patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Generator
 
+## Unreleased
+- Fixed a bug where element condition and query classes weren’t getting imported for the element class. ([#13](https://github.com/craftcms/generator/pull/13))
+- Fixed a bug where `ecs.php` class imports were missing characters. ([#13](https://github.com/craftcms/generator/pull/13))
+
 ## 1.2.0 - 2023-01-11
 - Added the GraphQL directive generator (`gql-directive`).
 - Fixed a bug where plugins’ `composer.json` would include invalid `require-dev` dependencies if ECS or PHPStan weren’t used. ([#9](https://github.com/craftcms/generator/issues/9))

--- a/src/generators/ElementType.php
+++ b/src/generators/ElementType.php
@@ -140,17 +140,14 @@ MD;
             ->addUse(ElementQueryInterface::class)
             ->addUse(Response::class)
             ->addUse(UrlHelper::class)
-            ->addUse(User::class);
+            ->addUse(User::class)
+            ->addUse(sprintf('%s\\%s', $this->conditionNamespace, $this->conditionName))
+            ->addUse(sprintf('%s\\%s', $this->queryNamespace, $this->queryName));
 
         $class = $this->createClass($this->className, BaseElement::class, [
             self::CLASS_METHODS => $this->elementClassMethods(),
         ]);
         $namespace->add($class);
-
-        // Add generated Condition and Query classes:
-        $namespace
-            ->addUse(sprintf('%s\\%s', $this->conditionNamespace, $this->conditionName))
-            ->addUse(sprintf('%s\\%s', $this->queryNamespace, $this->queryName));
 
         $class->setComment(sprintf('%s element type', StringHelper::toTitleCase($this->displayName)));
 

--- a/src/generators/ElementType.php
+++ b/src/generators/ElementType.php
@@ -297,7 +297,7 @@ return \$user->can('delete$this->pluralName');
 PHP,
             'canCreateDrafts' => 'return true;',
             'cpEditUrl' => "return sprintf('$this->pluralKebabCasedName/%s', \$this->getCanonicalId());",
-            'getPostEditUrl' => "UrlHelper::cpUrl('$this->pluralKebabCasedName');",
+            'getPostEditUrl' => "return UrlHelper::cpUrl('$this->pluralKebabCasedName');",
             'prepareEditScreen' => <<<PHP
 /** @var Response|CpScreenResponseBehavior \$response */
 \$response->crumbs([

--- a/src/generators/ElementType.php
+++ b/src/generators/ElementType.php
@@ -147,6 +147,11 @@ MD;
         ]);
         $namespace->add($class);
 
+        // Add generated Condition and Query classes:
+        $namespace
+            ->addUse(sprintf('%s\\%s', $this->conditionNamespace, $this->conditionName))
+            ->addUse(sprintf('%s\\%s', $this->queryNamespace, $this->queryName));
+
         $class->setComment(sprintf('%s element type', StringHelper::toTitleCase($this->displayName)));
 
         $this->writePhpClass($namespace);

--- a/src/generators/Plugin.php
+++ b/src/generators/Plugin.php
@@ -507,8 +507,8 @@ MD;
 
 declare(strict_types=1);
 
-use craft\ecs\SetList;
-use Symplify\EasyCodingStandard\Config\ECSConfig;
+use craft\\ecs\\SetList;
+use Symplify\\EasyCodingStandard\\Config\\ECSConfig;
 
 return static function(ECSConfig \$ecsConfig): void {
     \$ecsConfig->paths([


### PR DESCRIPTION
Fixes a couple things I noticed in the process of testing Element types:

- `ecs.php` output no longer contains `esc` character (`\e`);
- Element types include `use` statements for the `MyElementTypeQuery` and `MyElementTypeCondition` classes that are generated and referenced later in the class;