### PR TITLE
Fix typo in Element Exporter generator

### DIFF
--- a/src/generators/ElementExporter.php
+++ b/src/generators/ElementExporter.php
@@ -65,7 +65,7 @@ MD);
             'export' => <<<PHP
 \$data = [];
 
-foreaech (\$query->all() as \$element) {
+foreach (\$query->all() as \$element) {
     // ...
 } 
 


### PR DESCRIPTION
`foreaech` &rarr; `foreach`!