### PR TITLE
add void return to init method

### DIFF
--- a/src/generators/Module.php
+++ b/src/generators/Module.php
@@ -139,6 +139,8 @@ MD,
         $class = $this->createClass('Module', YiiModule::class, [
             self::CLASS_METHODS => $this->methods(),
         ]);
+        $class->getMethod('init')
+            ->setReturnType('void');
         $namespace->add($class);
 
         $class->setComment(<<<EOD

--- a/src/generators/Plugin.php
+++ b/src/generators/Plugin.php
@@ -356,6 +356,8 @@ YAML;
             self::CLASS_PROPERTIES => $this->pluginProperties(),
             self::CLASS_METHODS => $this->pluginMethods(),
         ]);
+        $class->getMethod('init')
+            ->setReturnType('void');
         $namespace->add($class);
 
         $class->setComment(<<<EOD


### PR DESCRIPTION
### Description

Add `void` return type to generated init method to avoid phpstan warning

### Related issues

https://github.com/craftcms/generator/issues/20