### PR TITLE
Twig Message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for Craft Generator
 
 ## Unreleased
+- Added `craft\generator\BaseGenerator::messageTwig()`. ([#25](https://github.com/craftcms/generator/pull/25))
 - The plugin generator now ensures that the project’s `composer.json` file has `minimum-stability: dev` and `prefer-stable: true` set. ([#22](https://github.com/craftcms/generator/issues/22))
 - Fixed a bug where the Service generator was suggesting adding a `config()` method which defined the service config, even when the target was a module. ([#24](https://github.com/craftcms/generator/issues/24))
 

--- a/src/BaseGenerator.php
+++ b/src/BaseGenerator.php
@@ -733,13 +733,44 @@ abstract class BaseGenerator extends BaseObject
     protected function messagePhp(string $message): string
     {
         $messagePhp = var_export($message, true);
-        $category = match (true) {
+        $category = $this->getTranslationCategory();
+
+        return $category ? sprintf("Craft::t('%s', %s)", $category, $messagePhp) : $messagePhp;
+    }
+
+    /**
+     * Places a string into a Twig translation statement.
+     *
+     * Output is not enclosed in any `{{ ... }}` or `{% ... %}` tags.
+     *
+     * @param string $message The string to output
+     * @return string Twig statement
+     */
+    protected function messageTwig(string $message): string
+    {
+        $messageTwig = var_export($message, true);
+        $category = $this->getTranslationCategory();
+
+        return $category ? sprintf("'%1\$s\'|t('%2\$s\', %1\$s)", $category, $messageTwig) : $messageTwig;
+    }
+
+    /**
+     * Resolves an appropriate translation category for the target module/component.
+     *
+     * The result is not guaranteed to be valid:
+     * - Modules can register translation categories with any handle/ID they like (and the ID of a module can change at any time);
+     * - Plugins may register additional translation categories (non-standard) that we don’t/can’t know about;
+     * - The `site` translation category used by the front-end (and some modules) is not taken into consideration;
+     *
+     * @return string|null Translation category handle
+     */
+    protected function getTranslationCategory(): ?string
+    {
+        return match (true) {
             $this->module instanceof Application => 'app',
             $this->module instanceof PluginInterface => $this->module->id,
             default => null,
         };
-
-        return $category ? sprintf("Craft::t('%s', %s)", $category, $messagePhp) : $messagePhp;
     }
 
     /**

--- a/src/BaseGenerator.php
+++ b/src/BaseGenerator.php
@@ -733,7 +733,7 @@ abstract class BaseGenerator extends BaseObject
     protected function messagePhp(string $message): string
     {
         $messagePhp = var_export($message, true);
-        $category = $this->getTranslationCategory();
+        $category = $this->translationCategory();
 
         return $category ? sprintf("Craft::t('%s', %s)", $category, $messagePhp) : $messagePhp;
     }
@@ -745,11 +745,12 @@ abstract class BaseGenerator extends BaseObject
      *
      * @param string $message The string to output
      * @return string Twig statement
+     * @since 1.6.0
      */
     protected function messageTwig(string $message): string
     {
         $messageTwig = var_export($message, true);
-        $category = $this->getTranslationCategory();
+        $category = $this->translationCategory();
 
         return $category ? sprintf("'%1\$s\'|t('%2\$s\', %1\$s)", $category, $messageTwig) : $messageTwig;
     }
@@ -764,7 +765,7 @@ abstract class BaseGenerator extends BaseObject
      *
      * @return string|null Translation category handle
      */
-    protected function getTranslationCategory(): ?string
+    private function translationCategory(): ?string
     {
         return match (true) {
             $this->module instanceof Application => 'app',


### PR DESCRIPTION
### Description

Adds `BaseGenerator::messageTwig($str)` to complement `BaseGenerator::messagePhp($str)`, and refactors the determination of a "translation category" to another method.

Found a use for this while working on [Commerce generators](https://github.com/craftcms/commerce/pull/3235).