### PR TITLE
Customizable Module Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Craft Generator
 
+## Unreleased
+- Generator now prompts for new modules’ names. ([#28](https://github.com/craftcms/generator/pull/28))
+
 ## 1.6.1 - 2023-08-10
 - Fixed a double-backslash bug.
 

--- a/src/generators/Module.php
+++ b/src/generators/Module.php
@@ -31,12 +31,18 @@ class Module extends BaseGenerator
     private string $id;
     private string $targetDir;
     private string $rootNamespace;
+    private string $className;
     private bool $bootstrap;
 
     public function run(): bool
     {
         $this->id = $this->idPrompt('Module ID:', [
             'required' => true,
+        ]);
+
+        $this->className = $this->classNamePrompt('Base module class name:', [
+            'required' => true,
+            'default' => 'Module',
         ]);
 
         [$this->targetDir, $this->rootNamespace, $addedRoot] = $this->autoloadableDirectoryPrompt('Module location:', [
@@ -68,7 +74,7 @@ MD;
         $appConfigPath = Craft::$app->getConfig()->getConfigFilePath('app');
 
         if (!$this->modifyFile($appConfigPath, function(Workspace $workspace) {
-            $moduleClassName = $workspace->importClass("$this->rootNamespace\\Module");
+            $moduleClassName = $workspace->importClass("$this->rootNamespace\\$this->className");
 
             if (!$workspace->modifyCode(new NodeVisitor(
                 enterNode: function(Node $node) use ($workspace, $moduleClassName) {
@@ -101,7 +107,7 @@ MD;
         })) {
             $fallbackExample = <<<MD
 'modules' => [
-    '$this->id' => \\$this->rootNamespace\\Module::class,
+    '$this->id' => \\$this->rootNamespace\\$this->className::class,
 ],
 MD;
             if ($this->bootstrap) {
@@ -136,17 +142,19 @@ MD,
             ->addUse(Craft::class)
             ->addUse(YiiModule::class, 'BaseModule');
 
-        $class = $this->createClass('Module', YiiModule::class, [
+        $class = $this->createClass($this->className, YiiModule::class, [
             self::CLASS_METHODS => $this->methods(),
         ]);
         $class->getMethod('init')
             ->setReturnType('void');
         $namespace->add($class);
 
-        $class->setComment(<<<EOD
-$this->id module
+        $name = $this->className !== 'Module' ? $this->className : $this->id;
 
-@method static Module getInstance()
+        $class->setComment(<<<EOD
+$name module
+
+@method static $this->className getInstance()
 EOD
         );
 


### PR DESCRIPTION
For projects with multiple modules, base class file/names can get a little confusing. This prompts for a class name (defaulting to `Module`) when generating a new module.

Mentioned on [Discord](https://discord.com/channels/456442477667418113/456442884258922529/1143953849799954573). Figured it was a worthwhile patch!