### PR TITLE
Add strict_types by default

### DIFF
--- a/src/BaseGenerator.php
+++ b/src/BaseGenerator.php
@@ -701,6 +701,7 @@ abstract class BaseGenerator extends BaseObject
         $path = sprintf('%s/%s.php', $basePath, $class->getName());
 
         $file = new PhpFile();
+        $file->setStrictTypes();
         $file->addNamespace($namespace);
         $this->writePhpFile($path, $file);
     }

--- a/src/generators/Module.php
+++ b/src/generators/Module.php
@@ -131,6 +131,7 @@ MD,
     private function writeModuleClass(): void
     {
         $file = new PhpFile();
+        $file->setStrictTypes();
 
         $namespace = $file->addNamespace($this->rootNamespace)
             ->addUse(Craft::class)

--- a/src/generators/Plugin.php
+++ b/src/generators/Plugin.php
@@ -395,6 +395,7 @@ YAML;
     private function writePluginClass(): void
     {
         $file = new PhpFile();
+        $file->setStrictTypes();
 
         $namespace = $file->addNamespace($this->rootNamespace)
             ->addUse(Craft::class)
@@ -748,6 +749,7 @@ PHP
     private function writeSettingsModel(): void
     {
         $file = new PhpFile();
+        $file->setStrictTypes();
 
         $namespace = $file->addNamespace($this->settingsNamespace)
             ->addUse(Craft::class)


### PR DESCRIPTION
### Description
This PR just adds `declare(strict_types=1);` to each generated php file.


