### PR TITLE
Fix minor syntax issues in Element Action generator

### DIFF
--- a/src/generators/ElementAction.php
+++ b/src/generators/ElementAction.php
@@ -67,7 +67,7 @@ Craft::\$app->getView()->registerJsWithVars(fn(\$type) => <<<JS
             bulk: true,
     
             // Return whether the action should be available depending on which elements are selected
-            validateSelection: (selectedItems) {
+            validateSelection: (selectedItems) => {
               return true;
             },
     

--- a/src/generators/ElementAction.php
+++ b/src/generators/ElementAction.php
@@ -81,6 +81,8 @@ Craft::\$app->getView()->registerJsWithVars(fn(\$type) => <<<JS
         });
     })();
 JS, [static::class]);
+
+return null;
 PHP,
             'performAction' => <<<PHP
 \$elements = \$query->all();


### PR DESCRIPTION
### Description

Addresses two small issues in the code generated by the Element Action generator:
1. A syntax error in the JS method definition for `validateSelection()`, which causes an “Unexpected token” error when selecting elements on an element index
2. A return type exception in the PHP `getTriggerHtml()` method — method's return type is `?string`, but the method body only registers some JS, and doesn't have a return, which causes the `element-indexes/get-elements` action to throw a 500 error.

### Related issues

No related issues.