### PR TITLE
Fix documentation link for v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Release Notes for Craft Generator
 
-## Unreleased
-- Fix links to [Events documentation](https://craftcms.com/docs/5.x/extend/events.html) for v2 (Craft 5).
-
 ## 2.0.1 - 2024-03-08
 - Generated field types, utilities, and widget types now provide default icons.
 - Fixed an error that occurred when generating a utility. ([#34](https://github.com/craftcms/generator/issues/34))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Craft Generator
 
+## Unreleased
+- Fix links to [Events documentation](https://craftcms.com/docs/5.x/extend/events.html) for v2 (Craft 5).
+
 ## 2.0.1 - 2024-03-08
 - Generated field types, utilities, and widget types now provide default icons.
 - Fixed an error that occurred when generating a utility. ([#34](https://github.com/craftcms/generator/issues/34))

--- a/src/generators/Module.php
+++ b/src/generators/Module.php
@@ -164,7 +164,7 @@ EOD
             ->setReturnType('void')
             ->setBody(<<<EOD
 // Register event handlers here ...
-// (see https://craftcms.com/docs/4.x/extend/events.html to get started)
+// (see https://craftcms.com/docs/5.x/extend/events.html to get started)
 EOD);
 
         $this->writePhpClass($namespace);

--- a/src/generators/Plugin.php
+++ b/src/generators/Plugin.php
@@ -428,7 +428,7 @@ EOD);
             ->setReturnType('void')
             ->setBody(<<<EOD
 // Register event handlers here ...
-// (see https://craftcms.com/docs/4.x/extend/events.html to get started)
+// (see https://craftcms.com/docs/5.x/extend/events.html to get started)
 EOD);
 
         $this->writePhpFile("$this->targetDir/src/$this->className.php", $file);


### PR DESCRIPTION
Links were pointing to Craft 4 documentation.

