### PR TITLE
Replace deprecated conditionRuleTypes() method

### DIFF
--- a/src/generators/ElementType.php
+++ b/src/generators/ElementType.php
@@ -364,7 +364,7 @@ PHP,
     {
         return [
             'selectableConditionRules' => <<<PHP
-return array_merge(parent::conditionRuleTypes(), [
+return array_merge(parent::selectableConditionRules(), [
     // ...
 ]);
 PHP,


### PR DESCRIPTION
This replaces the deprecated `parent::conditionRuleTypes()` included in the generated `selectableConditionRules()` 