### PR TITLE
Upgrade nikic/php-parser to ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "^8.2",
     "craftcms/cms": "^5.0.0-beta.1",
     "nette/php-generator": "^4.0",
-    "nikic/php-parser": "^4.15"
+    "nikic/php-parser": "^5.0 || ^4.15"
   },
   "require-dev": {
     "craftcms/ecs": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "^8.2",
     "craftcms/cms": "^5.0.0-beta.1",
     "nette/php-generator": "^4.0",
-    "nikic/php-parser": "^5.0 || ^4.15"
+    "nikic/php-parser": "^5.0"
   },
   "require-dev": {
     "craftcms/ecs": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5eb0c9231e734a1ad36de1bc82a5100",
+    "content-hash": "ea738a5d6ef1d961898e630f6d5f3441",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -2110,25 +2110,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -2136,7 +2138,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2160,9 +2162,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -9229,9 +9231,9 @@
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/BaseGenerator.php
+++ b/src/BaseGenerator.php
@@ -819,7 +819,7 @@ abstract class BaseGenerator extends BaseObject
      * @param string $eventClass The event class that will be passed.
      * @param string $eventProperty The property to register the component to.
      * @return bool Whether an `attachEventHandlers()` method could be found.
-     * @see https://github.com/nikic/PHP-Parser/blob/4.x/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing
+     * @see https://github.com/nikic/PHP-Parser/blob/v5.4.0/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing
      */
     protected function addRegistrationEventHandlerCode(
         string $class,

--- a/src/Workspace.php
+++ b/src/Workspace.php
@@ -14,7 +14,6 @@ use Nette\PhpGenerator\Constant;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\PsrPrinter;
 use PhpParser\Comment\Doc;
-use PhpParser\Lexer\Emulative;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
@@ -30,7 +29,7 @@ use PhpParser\NodeAbstract;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor as NodeVisitorInterface;
 use PhpParser\NodeVisitor\CloningVisitor;
-use PhpParser\Parser\Php7;
+use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use yii\base\Event;
 use yii\base\InvalidArgumentException;
@@ -226,18 +225,10 @@ PHP;
     {
         // Format-preserving pretty printing setup
         // see https://github.com/nikic/PHP-Parser/blob/4.x/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing
-        $lexer = new Emulative([
-            'usedAttributes' => [
-                'comments',
-                'startLine', 'endLine',
-                'startTokenPos', 'endTokenPos',
-            ],
-        ]);
-        $parser = new Php7($lexer);
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new CloningVisitor());
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $traverser = new NodeTraverser(new CloningVisitor());
         $oldStmts = $parser->parse($this->code);
-        $oldTokens = $lexer->getTokens();
+        $oldTokens = $parser->getTokens();
         $newStmts = $traverser->traverse($oldStmts);
 
         // Capture the original code

--- a/src/Workspace.php
+++ b/src/Workspace.php
@@ -224,7 +224,7 @@ PHP;
     public function modifyCode(NodeVisitorInterface $visitor): bool
     {
         // Format-preserving pretty printing setup
-        // see https://github.com/nikic/PHP-Parser/blob/4.x/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing
+        // see https://github.com/nikic/PHP-Parser/blob/v5.4.0/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing
         $parser = (new ParserFactory())->createForHostVersion();
         $traverser = new NodeTraverser(new CloningVisitor());
         $oldStmts = $parser->parse($this->code);

--- a/src/Workspace.php
+++ b/src/Workspace.php
@@ -225,7 +225,7 @@ PHP;
     {
         // Format-preserving pretty printing setup
         // see https://github.com/nikic/PHP-Parser/blob/4.x/doc/component/Pretty_printing.markdown#formatting-preserving-pretty-printing
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $parser = (new ParserFactory())->createForHostVersion();
         $traverser = new NodeTraverser(new CloningVisitor());
         $oldStmts = $parser->parse($this->code);
         $oldTokens = $parser->getTokens();

--- a/src/helpers/Code.php
+++ b/src/helpers/Code.php
@@ -128,7 +128,7 @@ abstract class Code
      */
     public static function parseSnippet(string $snippet): array
     {
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $parser = (new ParserFactory())->createForHostVersion();
         return $parser->parse("<?php\n$snippet") ?? [];
     }
 

--- a/src/helpers/Code.php
+++ b/src/helpers/Code.php
@@ -128,7 +128,7 @@ abstract class Code
      */
     public static function parseSnippet(string $snippet): array
     {
-        $parser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
         return $parser->parse("<?php\n$snippet") ?? [];
     }
 


### PR DESCRIPTION
### Description
Updates the nikic/php-parser requirement to ^5.0

Primarily consists of [changes to the parser factory](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-parser-factory) and [changes to the lexer](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-lexer)